### PR TITLE
License change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,181 @@
+====================================================================================
+LGPL 3.0 : The License This Project Uses
+====================================================================================
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+
+
+
+
+
+====================================================================================
+GPL 3.0 : Provided for Completeness
+====================================================================================
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,36 @@
+---
+title: GNU Lesser General Public License v3.0
+spdx-id: LGPL-3.0
+nickname: GNU LGPLv3
+redirect_from: /licenses/lgpl-v3/
+
+description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
+
+how: This license is an additional set of permissions to the <a href="/licenses/gpl-3.0">GNU GPLv3</a> license. Follow the instructions to apply the GNU GPLv3, in the root of your source code. Then add another file named COPYING.LESSER and copy the text.
+
+note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
+
+using:
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - patent-use
+  - private-use
+
+conditions:
+  - include-copyright
+  - disclose-source
+  - document-changes
+  - same-license--library
+
+limitations:
+  - liability
+  - warranty
+
+---
+
 ====================================================================================
 LGPL 3.0 : The License This Project Uses
 ====================================================================================

--- a/LICENSE
+++ b/LICENSE
@@ -1,36 +1,3 @@
----
-title: GNU Lesser General Public License v3.0
-spdx-id: LGPL-3.0
-nickname: GNU LGPLv3
-redirect_from: /licenses/lgpl-v3/
-
-description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
-
-how: This license is an additional set of permissions to the <a href="/licenses/gpl-3.0">GNU GPLv3</a> license. Follow the instructions to apply the GNU GPLv3, in the root of your source code. Then add another file named COPYING.LESSER and copy the text.
-
-note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
-
-using:
-
-permissions:
-  - commercial-use
-  - modifications
-  - distribution
-  - patent-use
-  - private-use
-
-conditions:
-  - include-copyright
-  - disclose-source
-  - document-changes
-  - same-license--library
-
-limitations:
-  - liability
-  - warranty
-
----
-
 ====================================================================================
 LGPL 3.0 : The License This Project Uses
 ====================================================================================

--- a/include/anoptic_memalign.h
+++ b/include/anoptic_memalign.h
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 /**
  * @file anoptic_memalign.h
  * @brief Platform-agnostic memory management API for the Anoptic Engine.

--- a/include/anoptic_threads.h
+++ b/include/anoptic_threads.h
@@ -1,0 +1,3 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */

--- a/include/anoptic_time.h
+++ b/include/anoptic_time.h
@@ -1,0 +1,3 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */

--- a/include/anoptic_vulkan.h
+++ b/include/anoptic_vulkan.h
@@ -1,0 +1,3 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */

--- a/src/engine/main.c
+++ b/src/engine/main.c
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #include "engine/main.h" // This works
 

--- a/src/engine/main.h
+++ b/src/engine/main.h
@@ -1,22 +1,3 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */

--- a/src/platform/linux/linux_memory.c
+++ b/src/platform/linux/linux_memory.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #ifdef __linux__
 
 #include "anoptic_memalign.h"

--- a/src/platform/linux/linux_threads.c
+++ b/src/platform/linux/linux_threads.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #ifdef __linux__
 #include <unistd.h>
 

--- a/src/platform/linux/linux_time.c
+++ b/src/platform/linux/linux_time.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #ifdef __linux__
 #include <unistd.h>
 

--- a/src/platform/windows/win_memory.c
+++ b/src/platform/windows/win_memory.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #ifdef _WIN32
 
 #include "anoptic_memalign.h"

--- a/src/platform/windows/win_threads.c
+++ b/src/platform/windows/win_threads.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #if defined(_WIN32)
 #include <Windows.h>
 

--- a/src/platform/windows/win_time.c
+++ b/src/platform/windows/win_time.c
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
+
 #if defined(_WIN32)
 #include <Windows.h>
 

--- a/src/vulkan_backend/instanceInit.c
+++ b/src/vulkan_backend/instanceInit.c
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 
 #include <stdio.h>

--- a/src/vulkan_backend/instanceInit.h
+++ b/src/vulkan_backend/instanceInit.h
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #ifndef INSTANCEINIT_H
 #define INSTANCEINIT_H

--- a/src/vulkan_backend/pipeline.c
+++ b/src/vulkan_backend/pipeline.c
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #include "pipeline.h"
 

--- a/src/vulkan_backend/pipeline.h
+++ b/src/vulkan_backend/pipeline.h
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #ifndef PIPELINE_H
 #define PIPELINE_H

--- a/src/vulkan_backend/structs.h
+++ b/src/vulkan_backend/structs.h
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #ifndef STRUCTS_H
 #define STRUCTS_H

--- a/src/vulkan_backend/vulkanMaster.c
+++ b/src/vulkan_backend/vulkanMaster.c
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 
 #include <stdio.h>

--- a/src/vulkan_backend/vulkanMaster.h
+++ b/src/vulkan_backend/vulkanMaster.h
@@ -1,25 +1,6 @@
-//========================================================================
-// Anoptic Engine 0.01
-//------------------------------------------------------------------------
-// Copyright (c) 2023 Matei Anghel
-// Copyright (c) 2023 Cristian Necsoiu
-//
-// This file is part of 'The Anoptic Engine'.
-// 
-// 'The Anoptic Engine' is free software: you can redistribute it
-// and/or modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation, version 3 of the License.
-//
-// 'The Anoptic Engine' is distributed WITHOUT ANY WARRANTY, without
-// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-// See the GNU General Public License for more details.
-//
-// This notice may not be removed or altered from any source distribution.
-//
-// You should have received a copy of the GNU General Public License along with this software. 
-// If not, see <https://www.gnu.org/licenses/>.
-//
-//========================================================================
+/* SPDX-FileCopyrightText: 2023 Anoptic Game Engine Authors
+ *
+ * SPDX-License-Identifier: LGPL-3.0 */
 
 #ifndef VULKANMASTER_H
 #define VULKANMASTER_H


### PR DESCRIPTION
License changed to LGPL3.0 because we want people to be able to integrate the engine into their otherwise proprietary games, whilst also making sure that the game engine _itself_ remains free and open-source forever.